### PR TITLE
Pixel offset

### DIFF
--- a/LEDStripDriver/LEDStripDriver.ino
+++ b/LEDStripDriver/LEDStripDriver.ino
@@ -15,7 +15,6 @@
  * ~ Configuration ~
  * Edit config.h to set NeoPixel, WiFi and web server parameters.
  * See animations.h for adding new animations.
- * 
  */
 
 #include <ESPAsyncWebServer.h>

--- a/LEDStripDriver/animationFunctionHelpers.h
+++ b/LEDStripDriver/animationFunctionHelpers.h
@@ -41,7 +41,7 @@ void initLEDs() {
  * Use this function to set all pixels to a color
  */
 void setAllPixels(RgbColor color) {
-  for (int count = 0; count <= LED_COUNT; count++) {
+  for (int count = START_LED; count <= LED_COUNT; count++) {
     strip.SetPixelColor(count, color); 
   }   
   
@@ -102,7 +102,7 @@ void BlendAnimUpdate(const AnimationParam& param) {
         param.progress);
 
     // apply the color to the strip
-    for (uint16_t pixel = 0; pixel < LED_COUNT; pixel++)
+    for (uint16_t pixel = START_LED; pixel < LED_COUNT; pixel++)
     {
         strip.SetPixelColor(pixel, updatedColor);
     }

--- a/LEDStripDriver/animationFunctions.h
+++ b/LEDStripDriver/animationFunctions.h
@@ -169,12 +169,15 @@ void copLightsMix(void * pvParameters) {
 void rainyDay(void * pvParameters) {
   (void) pvParameters;
 
+  RgbColor thisWhite = RgbColor(5);
+  
+
   int LightningFrequency = 20;
   int count = 0;
 
   // Startup animation
   for (int count = 0; count <= LED_COUNT; count++) {
-    strip.SetPixelColor(count, white);
+    strip.SetPixelColor(count, thisWhite);
     vTaskDelay(5 / portTICK_PERIOD_MS);
     strip.Show();
   }
@@ -190,7 +193,7 @@ void rainyDay(void * pvParameters) {
       strip.Show();
       vTaskDelay(50 / portTICK_PERIOD_MS);
       
-      setAllPixels(white); 
+      setAllPixels(thisWhite); 
     }
   
     if (count % LightningFrequency * 2 == 0) {
@@ -213,7 +216,7 @@ void rainyDay(void * pvParameters) {
       strip.Show();
       vTaskDelay(50 / portTICK_PERIOD_MS);
       
-      setAllPixels(white); 
+      setAllPixels(thisWhite); 
   
       count = 0;
     }
@@ -222,7 +225,7 @@ void rainyDay(void * pvParameters) {
     int Pixel2Index = random(LED_COUNT);
     int Pixel3Index = random(LED_COUNT);
     
-    for (int count = SATURATION; count >= 15; count--) {
+    for (int count = 40; count >= 15; count--) {
        strip.SetPixelColor(Pixel1Index, RgbColor(0, 0, count));
        strip.SetPixelColor(Pixel2Index, RgbColor(0, 0, count));
        strip.SetPixelColor(Pixel3Index, RgbColor(0, 0, count));
@@ -230,15 +233,67 @@ void rainyDay(void * pvParameters) {
        strip.Show(); 
     }
   
-    strip.SetPixelColor(Pixel1Index, white);
-    strip.SetPixelColor(Pixel2Index, white);
-    strip.SetPixelColor(Pixel3Index, white);
+    strip.SetPixelColor(Pixel1Index, thisWhite);
+    strip.SetPixelColor(Pixel2Index, thisWhite);
+    strip.SetPixelColor(Pixel3Index, thisWhite);
     
     strip.Show();
   
     count++;
+    vTaskDelay(500 / portTICK_PERIOD_MS);
   }
 }
 
+/**
+ * The super mellow green animation
+ */
+ void melloYello(void * pvParameters) {
+  (void) pvParameters;
 
+  int count = 0;
+  int loopdirection = 0;
+
+  RgbColor thisGreen(0, 15, 0);
+
+  // Startup animation
+  for (int count = 0; count <= LED_COUNT; count++) {
+    strip.SetPixelColor(count, thisGreen);
+    delay(5);
+    strip.Show();
+  }
+
+  while (true) {
+    if (count >= LED_COUNT) 
+      loopdirection = 1;
+    else if (count <= 0 && loopdirection == 1)
+      loopdirection = 0;
+
+    strip.SetPixelColor(count, black);
+    
+    if (loopdirection == 0) {
+       int brightness = 25;
+       
+       for(int i = count; i >= count - 25; i--) {
+         strip.SetPixelColor(i, RgbColor (brightness, brightness, 0));
+         brightness--;
+       } 
+       
+        strip.SetPixelColor(count - 25, thisGreen);
+        count++;
+     } else {
+       int brightness = 25;
+       
+       for(int i = count; i <= count + 25; i++) {
+         strip.SetPixelColor(i, RgbColor (brightness, brightness, 0));
+         brightness--;
+       } 
+       
+        strip.SetPixelColor(count + 25, thisGreen);
+        count--;
+     }
+      
+      strip.Show();
+      delay(25);
+    }
+ }
 #endif

--- a/LEDStripDriver/animationFunctions.h
+++ b/LEDStripDriver/animationFunctions.h
@@ -24,11 +24,11 @@ void copLightsAlternating(void * pvParameters) {
   bool swapped = true;
   
   // Index for middle pixel
-  int median = LED_COUNT / 2;
+  int median = (LED_COUNT + START_LED) / 2;
 
   // Startup animation
   // Turn first half red
-  for (int count = 0; count <= median; count++) {
+  for (int count = START_LED; count <= median; count++) {
     strip.SetPixelColor(count, red);
     vTaskDelay(5 / portTICK_PERIOD_MS);
     strip.Show();
@@ -60,7 +60,7 @@ void copLightsAlternating(void * pvParameters) {
     vTaskDelay(200 / portTICK_PERIOD_MS);
     
     // Set first half of strip
-    for (int count = 0; count <= median; count++) {
+    for (int count = START_LED; count <= median; count++) {
       strip.SetPixelColor(count, firstColor);
     }
   
@@ -82,18 +82,18 @@ void copLightsLineOut(void * pvParameters) {
   (void) pvParameters;
 
   // Current pixel being changed
-  int pixelIndex = 0;
+  int pixelIndex = START_LED;
 
   // Whether to set red or blue first
   bool swapped = true;
   
   // Index for middle pixel
-  int median = LED_COUNT / 2;
+  int median = (LED_COUNT + START_LED) / 2;
   int lineSize = 36; 
 
   // Startup animation
   // Red Line Out
-  for (int count = 0; count <= median; count++) {
+  for (int count = START_LED; count <= median; count++) {
     strip.SetPixelColor(count, red);
     vTaskDelay(5 / portTICK_PERIOD_MS);
     strip.Show();
@@ -127,7 +127,7 @@ void copLightsLineOut(void * pvParameters) {
       }
      
       setAllPixels(black);
-      pixelIndex = 0;
+      pixelIndex = START_LED;
     }
     
     strip.SetPixelColor(pixelIndex, red);
@@ -173,10 +173,10 @@ void rainyDay(void * pvParameters) {
   
 
   int LightningFrequency = 20;
-  int count = 0;
+  int count = START_LED;
 
   // Startup animation
-  for (int count = 0; count <= LED_COUNT; count++) {
+  for (int count = START_LED; count <= LED_COUNT; count++) {
     strip.SetPixelColor(count, thisWhite);
     vTaskDelay(5 / portTICK_PERIOD_MS);
     strip.Show();
@@ -218,12 +218,12 @@ void rainyDay(void * pvParameters) {
       
       setAllPixels(thisWhite); 
   
-      count = 0;
+      count = START_LED;
     }
     
-    int Pixel1Index = random(LED_COUNT);
-    int Pixel2Index = random(LED_COUNT);
-    int Pixel3Index = random(LED_COUNT);
+    int Pixel1Index = random(START_LED, LED_COUNT);
+    int Pixel2Index = random(START_LED, LED_COUNT);
+    int Pixel3Index = random(START_LED, LED_COUNT);
     
     for (int count = 40; count >= 15; count--) {
        strip.SetPixelColor(Pixel1Index, RgbColor(0, 0, count));
@@ -245,18 +245,18 @@ void rainyDay(void * pvParameters) {
 }
 
 /**
- * The super mellow green animation
+ * The super mellow green and yellow animation
  */
  void melloYello(void * pvParameters) {
   (void) pvParameters;
 
-  int count = 0;
+  int count = START_LED;
   int loopdirection = 0;
 
   RgbColor thisGreen(0, 15, 0);
 
   // Startup animation
-  for (int count = 0; count <= LED_COUNT; count++) {
+  for (int count = START_LED; count <= LED_COUNT; count++) {
     strip.SetPixelColor(count, thisGreen);
     delay(5);
     strip.Show();
@@ -265,30 +265,32 @@ void rainyDay(void * pvParameters) {
   while (true) {
     if (count >= LED_COUNT) 
       loopdirection = 1;
-    else if (count <= 0 && loopdirection == 1)
+    else if (count <= START_LED && loopdirection == 1)
       loopdirection = 0;
 
     strip.SetPixelColor(count, black);
     
     if (loopdirection == 0) {
        int brightness = 25;
+       int trailEnd = constrain(count - 25, START_LED, LED_COUNT);
        
-       for(int i = count; i >= count - 25; i--) {
+       for(int i = count; i >= trailEnd; i--) {
          strip.SetPixelColor(i, RgbColor (brightness, brightness, 0));
          brightness--;
        } 
        
-        strip.SetPixelColor(count - 25, thisGreen);
+        strip.SetPixelColor(trailEnd, thisGreen);
         count++;
      } else {
        int brightness = 25;
+       int trailEnd = constrain(count + 25, START_LED, LED_COUNT);
        
-       for(int i = count; i <= count + 25; i++) {
+       for(int i = count; i <= trailEnd; i++) {
          strip.SetPixelColor(i, RgbColor (brightness, brightness, 0));
          brightness--;
        } 
        
-        strip.SetPixelColor(count + 25, thisGreen);
+        strip.SetPixelColor(trailEnd, thisGreen);
         count--;
      }
       

--- a/LEDStripDriver/animations.h
+++ b/LEDStripDriver/animations.h
@@ -29,7 +29,8 @@ animationTableEntry animationTable[] =
   { 1, "Cop Lights Alternating", &copLightsAlternating },
   { 2, "Cop Lights Line Out",    &copLightsLineOut },
   { 3, "Cop Lights Mix",         &copLightsMix },
-  { 4, "Rainy Day",              &rainyDay },
+  { 4, "MelloYello",             &melloYello },
+  { 5, "Rainy Day",              &rainyDay },
   { NULL }
 };
 

--- a/LEDStripDriver/config.h
+++ b/LEDStripDriver/config.h
@@ -24,7 +24,7 @@ bool CORS_ENABLED = true; // True value adds the Access-Control-Allow-Origin hea
 
 // NeoPixel strip settings
 const uint8_t LED_PIN    = 4;   // GPIO pin connected to LED data
-const uint8_t LED_COUNT  = 56;  // Number of LEDs in the strip
+const uint8_t LED_COUNT  = 245; // Number of LEDs in the strip
 const uint8_t START_LED  = 1;   // Index of the first pixel (offset by one if using internal status LED)
 const uint8_t SATURATION = 128; // Maximum brightness
 

--- a/LEDStripDriver/config.h
+++ b/LEDStripDriver/config.h
@@ -13,9 +13,9 @@
 #define EEPROM_SIZE 2
 
 // WiFi settings
-const char * HOSTNAME     = "LEDStrip";   // Network device name
-const char * NETWORK_SSID = "YourSSID"; // Network SSID
-const char * NETWORK_PASS = "YourPassword";   // Network password
+const char * HOSTNAME     = "LEDStrip";     // Network device name
+const char * NETWORK_SSID = "YourSSID";     // Network SSID
+const char * NETWORK_PASS = "YourPassword"; // Network password
 const uint8_t CONNECT_TIMEOUT = 5; // Timeout for connection (seconds)
 bool BLOCK_UNTIL_CONNECTED = true; // Whether to block execution until connected
 
@@ -24,7 +24,8 @@ bool CORS_ENABLED = true; // True value adds the Access-Control-Allow-Origin hea
 
 // NeoPixel strip settings
 const uint8_t LED_PIN    = 4;   // GPIO pin connected to LED data
-const uint8_t LED_COUNT  = 245; // Number of LEDs in the strip
+const uint8_t LED_COUNT  = 56;  // Number of LEDs in the strip
+const uint8_t START_LED  = 1;   // Index of the first pixel (offset by one if using internal status LED)
 const uint8_t SATURATION = 128; // Maximum brightness
 
 // Network settings


### PR DESCRIPTION
### Added offset for 'sacrificial' LED
#### MERGE THIS BEFORE OFF BUTTON
The updated wiring requires a single NeoPixel in line with the strip to bump up the data voltage from 3.3v to 4.3v (based on [this](https://hackaday.com/2017/01/20/cheating-at-5v-ws2812-control-to-use-a-3-3v-data-line/) tutorial). Now, when writing to the strip, this single pixel is the first in line. This requires animations to start from index 1 instead of 0.

A neat side effect of this change is that we get an extra LED inside the box to play with. We can use it to indicate power status, flash it when an upload is detected, etc...
- Added START_LED to config.h (set to 1)
- Updated all animations to start from START_LED instead of 0